### PR TITLE
USGS now requires https

### DIFF
--- a/src/main/resources/srtmservers.properties
+++ b/src/main/resources/srtmservers.properties
@@ -1,5 +1,5 @@
 #default URL of server base dir for srtm files
-srtm.src.url.base=http://dds.cr.usgs.gov/srtm/version2_1/SRTM3/
+srtm.src.url.base=https://dds.cr.usgs.gov/srtm/version2_1/SRTM3/
 #default URLs of subdirectories for specified srtm files
 srtm.src.url.subdir.1=Africa/
 srtm.src.url.subdir.2=Australia/


### PR DESCRIPTION
The USGS server now returns a 301 Moved Permanently response code if it is accessed with http instead of https. Consequently, the plugin does not work anymore with default values as 301 redirection are not automatically followed.